### PR TITLE
Ensure background service activation and add call diagnostics

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -317,36 +317,17 @@ Future<void> _initializeAndConnectVPN() async {
 }
 
 Future<void> _initializeBackgroundCalling() async {
-  print('📞🔋 Initializing 24/7 background calling for both platforms...');
-  
   try {
-    if (Platform.isAndroid) {
-      print('🤖 ANDROID: Enhanced background service already configured');
-      print('🤖 ANDROID: Persistent SIP connection will activate when app goes background');
-      print('✅ ANDROID: Ready for 24/7 background calling');
-      
-    } else if (Platform.isIOS) {
-      print('🍎 iOS: Using foreground-persistent approach (no paid Apple Developer account)');
-      
-      try {
-        print('📱 iOS: Configuring extended background execution...');
-        print('💡 iOS: Without paid Apple Developer account, VoIP push notifications are not available');
-        print('💡 iOS: App will maintain SIP connection while in foreground');
-        print('📞 iOS: Background calling limited - upgrade to paid Apple Developer account for full VoIP');
-        
-        print('✅ iOS: Foreground calling configured');
-      } catch (e) {
-        print('❌ iOS: Configuration error: $e');
+    if (!PersistentBackgroundService.isServiceRunning()) {
+      if (Platform.isAndroid) {
+        await PersistentBackgroundService.startService();
+      } else if (Platform.isIOS) {
+        debugPrint(
+            '⚠️ iOS VoIP background mode requires a paid Apple Developer account');
       }
     }
-    
-    print('🎯 BACKGROUND CALLING CONFIGURED:');
-    print('🎯 ANDROID: Persistent background SIP service ✅');
-    print('🎯 iOS: Foreground calling only (requires paid Apple Developer account for VoIP) ⚠️');
-    
   } catch (e) {
-    print('❌ Background calling initialization error: $e');
-    print('💡 Background calling features may be limited');
+    debugPrint('❌ Background calling initialization error: $e');
   }
 }
 

--- a/example/lib/src/persistent_background_service.dart
+++ b/example/lib/src/persistent_background_service.dart
@@ -52,7 +52,9 @@ class PersistentBackgroundService {
         onBackground: onIosBackground,
       ),
     );
-    
+    await service.startService();
+    _isServiceRunning = await service.isRunning();
+
     print('🔄 Persistent Background Service configured');
   }
 

--- a/lib/src/rtc_session.dart
+++ b/lib/src/rtc_session.dart
@@ -588,6 +588,8 @@ class RTCSession extends EventManager implements Owner {
     // A local MediaStream is given, use it.
     if (mediaStream != null) {
       stream = mediaStream;
+      logger.d(
+          'Emitting stream event: originator=${Originator.local.name} id=${stream?.id}');
       emit(EventStream(
           session: this, originator: Originator.local, stream: stream));
     }
@@ -597,6 +599,8 @@ class RTCSession extends EventManager implements Owner {
       _localMediaStreamLocallyGenerated = true;
       try {
         stream = await navigator.mediaDevices.getUserMedia(mediaConstraints);
+        logger.d(
+            'Emitting stream event: originator=${Originator.local.name} id=${stream?.id}');
         emit(EventStream(
             session: this, originator: Originator.local, stream: stream));
       } catch (error) {
@@ -1655,6 +1659,8 @@ class RTCSession extends EventManager implements Owner {
       case 'unified-plan':
         _connection!.onTrack = (RTCTrackEvent event) {
           if (event.streams.isNotEmpty) {
+            logger.d(
+                'Emitting stream event: originator=${Originator.remote.name} id=${event.streams[0].id}');
             emit(EventStream(
                 session: this,
                 originator: Originator.remote,
@@ -1664,6 +1670,8 @@ class RTCSession extends EventManager implements Owner {
         break;
       case 'plan-b':
         _connection!.onAddStream = (MediaStream stream) {
+          logger.d(
+              'Emitting stream event: originator=${Originator.remote.name} id=${stream.id}');
           emit(EventStream(
               session: this, originator: Originator.remote, stream: stream));
         };
@@ -2092,6 +2100,8 @@ class RTCSession extends EventManager implements Owner {
             _localMediaStream?.addTrack(track);
           }
         }
+        logger.d(
+            'Emitting stream event: originator=${Originator.local.name} id=${_localMediaStream?.id}');
         emit(EventStream(
             session: this,
             originator: Originator.local,
@@ -2358,6 +2368,8 @@ class RTCSession extends EventManager implements Owner {
     // A stream is given, var the app set events such as 'peerconnection' and 'connecting'.
     if (mediaStream != null) {
       stream = mediaStream;
+      logger.d(
+          'Emitting stream event: originator=${Originator.local.name} id=${stream?.id}');
       emit(EventStream(
           session: this, originator: Originator.local, stream: stream));
     } // Request for user media access.
@@ -2366,6 +2378,8 @@ class RTCSession extends EventManager implements Owner {
       _localMediaStreamLocallyGenerated = true;
       try {
         stream = await navigator.mediaDevices.getUserMedia(mediaConstraints);
+        logger.d(
+            'Emitting stream event: originator=${Originator.local.name} id=${stream?.id}');
         emit(EventStream(
             session: this, originator: Originator.local, stream: stream));
       } catch (error) {
@@ -2769,6 +2783,8 @@ class RTCSession extends EventManager implements Owner {
           throw Exceptions.NotReadyError('Unkown sdp semantics $sdpSemantics');
       }
 
+      logger.d(
+          'Emitting stream event: originator=${Originator.local.name} id=${_localMediaStream?.id}');
       emit(EventStream(
           session: this,
           originator: Originator.local,

--- a/lib/src/sip_ua_helper.dart
+++ b/lib/src/sip_ua_helper.dart
@@ -102,6 +102,8 @@ class SIPUAHelper extends EventManager {
       MediaStream? mediaStream,
       List<String>? headers,
       Map<String, dynamic>? customOptions}) async {
+    logger.d(
+        'Initiating call to $target voiceOnly=$voiceOnly headers=$headers customOptions=${customOptions?.keys}');
     if (_ua != null && _ua!.isConnected()) {
       Map<String, dynamic> options = buildCallOptions(voiceOnly);
 
@@ -134,6 +136,8 @@ class SIPUAHelper extends EventManager {
     bool useUpdate = false,
     Function(IncomingMessage?)? done,
   }) async {
+    logger.d(
+        'Renegotiating call ${call.id} voiceOnly=$voiceOnly useUpdate=$useUpdate options=${options?.keys}');
     Map<String, dynamic> finalOptions = options ?? buildCallOptions(voiceOnly);
     call.renegotiate(options: finalOptions, useUpdate: useUpdate, done: done);
   }
@@ -484,6 +488,7 @@ class SIPUAHelper extends EventManager {
       logger.e('Call ${event.id} not found!');
       return;
     }
+    logger.d('Call ${call.id} state -> ${state.state}');
     call.state = state.state;
     // Copy to prevent concurrent modification exception
     List<SipUaHelperListener> listeners = _sipUaHelperListeners.toList();
@@ -556,6 +561,8 @@ class Call {
   bool voiceOnly;
 
   void answer(Map<String, dynamic> options, {MediaStream? mediaStream = null}) {
+    logger.d(
+        'Answer call $_id options=${options.keys} mediaStream=${mediaStream?.id}');
     assert(_session != null, 'ERROR(answer): rtc session is invalid!');
     if (mediaStream != null) {
       options['mediaStream'] = mediaStream;
@@ -564,6 +571,7 @@ class Call {
   }
 
   void refer(String target) {
+    logger.d('Refer call $_id to $target');
     assert(_session != null, 'ERROR(refer): rtc session is invalid!');
     ReferSubscriber refer = _session.refer(target)!;
     refer.on(EventReferTrying(), (EventReferTrying data) {});
@@ -575,6 +583,7 @@ class Call {
   }
 
   void hangup([Map<String, dynamic>? options]) {
+    logger.d('Hangup call $_id options=${options?.keys}');
     assert(_session != null, 'ERROR(hangup): rtc session is invalid!');
     if (peerConnection != null) {
       for (MediaStream? stream in peerConnection!.getLocalStreams()) {
@@ -604,21 +613,25 @@ class Call {
   }
 
   void hold() {
+    logger.d('Hold call $_id');
     assert(_session != null, 'ERROR(hold): rtc session is invalid!');
     _session.hold();
   }
 
   void unhold() {
+    logger.d('Unhold call $_id');
     assert(_session != null, 'ERROR(unhold): rtc session is invalid!');
     _session.unhold();
   }
 
   void mute([bool audio = true, bool video = true]) {
+    logger.d('Mute call $_id audio=$audio video=$video');
     assert(_session != null, 'ERROR(mute): rtc session is invalid!');
     _session.mute(audio, video);
   }
 
   void unmute([bool audio = true, bool video = true]) {
+    logger.d('Unmute call $_id audio=$audio video=$video');
     assert(_session != null, 'ERROR(unmute): rtc session is invalid!');
     _session.unmute(audio, video);
   }
@@ -628,16 +641,21 @@ class Call {
     bool useUpdate = false,
     Function(IncomingMessage?)? done,
   }) {
+    logger.d(
+        'Renegotiate call $_id options=${options?.keys} useUpdate=$useUpdate');
     assert(_session != null, 'ERROR(renegotiate): rtc session is invalid!');
     _session.renegotiate(options: options, useUpdate: useUpdate, done: done);
   }
 
   void sendDTMF(String tones, [Map<String, dynamic>? options]) {
+    logger.d('sendDTMF call $_id tones=$tones options=${options?.keys}');
     assert(_session != null, 'ERROR(sendDTMF): rtc session is invalid!');
     _session.sendDTMF(tones, options);
   }
 
   void sendInfo(String contentType, String body, Map<String, dynamic> options) {
+    logger.d(
+        'sendInfo call $_id contentType=$contentType bodyLength=${body.length} options=${options.keys}');
     assert(_session != null, 'ERROR(sendInfo): rtc session is invalid');
     _session.sendInfo(contentType, body, options);
   }


### PR DESCRIPTION
## Summary
- Start Android background service when absent and warn iOS about VoIP limitations
- Explicitly start configured background service and track its running state
- Add detailed call and media logging for call actions and stream events

## Testing
- ⚠️ `dart test` *(dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ae3b732970832a9ae7bc9964b359bb